### PR TITLE
Change API to no longer reject when statuscode > 400

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,11 +157,7 @@ function request (param) {
           }
         }
 
-        if (ret.status < 400) {
           return resolve(ret)
-        } else {
-          return reject(ret)
-        }
       })
     })
 


### PR DESCRIPTION
I want to conduct manual checks on the CouchDB response (checking if a db/document exists), in order to implement a "create if doesn't exist" on design documents.